### PR TITLE
Fetch all remotes.

### DIFF
--- a/godeps.go
+++ b/godeps.go
@@ -666,7 +666,7 @@ func (gitVCS) Clean(dir string) error {
 }
 
 func (gitVCS) Fetch(dir string) error {
-	_, err := runCmd(dir, "git", "fetch")
+	_, err := runCmd(dir, "git", "fetch", "--all")
 	return err
 }
 


### PR DESCRIPTION
I have my remotes generally set up so origin is my repos, and upstream reflects the project's upstream repository. godeps always used to return me an error godeps had previously set the tree to be some revision that was not the tip of master. By telling git to fetch all remotes rather than just the default (origin), we bring in the upstream changes too.
