### PR TITLE
include testing dependencies by default

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,0 +1,3 @@
+github.com/kisielk/gotool	git	0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220	2016-11-30T08:06:28Z
+gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
+launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87

--- a/godeps.go
+++ b/godeps.go
@@ -26,7 +26,8 @@ import (
 
 var (
 	revFile       = flag.String("u", "", "update dependencies")
-	testDeps      = flag.Bool("t", false, "include testing dependencies")
+	_             = flag.Bool("t", true, "(deprecated, superceded by -T) include testing dependencies")
+	noTestDeps    = flag.Bool("T", false, "do not include testing dependencies")
 	printCommands = flag.Bool("x", false, "show executed commands")
 	dryRun        = flag.Bool("n", false, "print but do not execute update commands")
 	_             = flag.Bool("f", true, "(deprecated, superceded by -F) when updating, try to fetch deps if the update fails")
@@ -99,7 +100,7 @@ func main() {
 			pkgs = []string{"."}
 		}
 		pkgs = gotool.ImportPaths(pkgs)
-		for _, info := range list(pkgs, *testDeps) {
+		for _, info := range list(pkgs, !*noTestDeps) {
 			fmt.Println(info)
 		}
 	}


### PR DESCRIPTION
Almost everyone wants to include testing dependencies.
Introduce an inverse flag, -T, to regain the old default behaviour
when required.

Also add a dependencies.tsv file.