### PR TITLE
remove errgo dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,3 +1,2 @@
 github.com/kisielk/gotool	git	0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220	2016-11-30T08:06:28Z
-gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87

--- a/godeps.go
+++ b/godeps.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/kisielk/gotool"
-	"gopkg.in/errgo.v1"
 
 	"github.com/rogpeppe/godeps/build"
 	"github.com/rogpeppe/godeps/pkgrepo"
@@ -562,7 +561,7 @@ func (ctxt *walkContext) walkDeps(pkgPath string, fromDir string, includeTests b
 	pkg, err := buildContext.Import(pkgPath, fromDir, 0)
 	ctxt.checked[pkg.ImportPath] = true
 	if err != nil && parentPkg != "" {
-		err = errgo.Notef(err, "cannot import from %q", parentPkg)
+		err = fmt.Errorf("cannot import from %q: %v", parentPkg, err)
 	}
 	descend := ctxt.visit(pkg, err)
 	if err != nil || !descend {


### PR DESCRIPTION
This caused problems when a build process using "go get -u"
tried to fetch errgo into a repo where errgo already existed.

We should somehow try to make godeps work better with
go get -u if that's possible.