### PR TITLE
support updating from Gopkg.lock files

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,2 +1,3 @@
-github.com/kisielk/gotool	git	0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220	2016-11-30T08:06:28Z
+github.com/kisielk/gotool	git	d6ce6262d87e3a4e153e86023ff56ae771554a41	2017-08-28T04:23:10Z
+github.com/pelletier/go-toml	git	4e9e0ee19b60b13eb79915933f44d8ed5f268bdd	2017-10-24T21:10:38Z
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87

--- a/deplock.go
+++ b/deplock.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pelletier/go-toml"
+)
+
+type rawLock struct {
+	Projects []rawLockedProject `toml:"projects"`
+}
+
+type rawLockedProject struct {
+	Name     string   `toml:"name"`
+	Branch   string   `toml:"branch,omitempty"`
+	Revision string   `toml:"revision"`
+	Version  string   `toml:"version,omitempty"`
+	Source   string   `toml:"source,omitempty"`
+	Packages []string `toml:"packages"`
+}
+
+func parseTOMLLockFile(file string) ([]*depInfo, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	raw := rawLock{}
+	err = toml.Unmarshal(data, &raw)
+	if err != nil {
+		return nil, err
+	}
+	var deps []*depInfo
+	for _, proj := range raw.Projects {
+		if proj.Source != "" {
+			return nil, fmt.Errorf("project %q has external source; godeps does not work with external sources", proj.Name)
+		}
+		deps = append(deps, &depInfo{
+			project: proj.Name,
+			VCSInfo: VCSInfo{
+				revid: proj.Revision,
+			},
+		})
+	}
+	return deps, nil
+}


### PR DESCRIPTION
This means that we can use godeps to update locked dependencies
in $GOPATH from a Gopkg.lock file.

One limitation is that `godeps -N` won't work correctly
because Gopkg.lock doesn't record commit dates.

Another is that Gopkg.lock files that specify external external sources
won't work because godeps doesn't support external sources.