### PR TITLE
do not segfault when updating Gopkg.lock files with non-existent deps

### DIFF
--- a/godeps.go
+++ b/godeps.go
@@ -198,6 +198,9 @@ func updateProject(info *depInfo) error {
 			return fmt.Errorf("cannot clean: %v", err)
 		}
 	}
+	if info.vcs == nil {
+		return fmt.Errorf("no VCS info available")
+	}
 	err := info.vcs.Update(info.dir, info.revid)
 	if err == nil || *noFetch {
 		return nil


### PR DESCRIPTION
This is a tempory workaround.